### PR TITLE
Avoid integral division to retain precision

### DIFF
--- a/offsetanimator/src/main/java/com/russelarms/offsetanimator/OffsetArcAnimator.java
+++ b/offsetanimator/src/main/java/com/russelarms/offsetanimator/OffsetArcAnimator.java
@@ -50,7 +50,7 @@ class OffsetArcAnimator extends OffsetAnimator {
                 * ArcUtils.cos(currentDegree);
         float y = arcMetric.getAxisPoint().y - arcMetric.getRadius()
                 * ArcUtils.sin(currentDegree);
-        view.setX(x - view.getWidth() / 2);
-        view.setY(y - view.getHeight() / 2);
+        view.setX(x - view.getWidth() / 2f);
+        view.setY(y - view.getHeight() / 2f);
     }
 }

--- a/offsetanimator/src/main/java/com/russelarms/offsetanimator/util/ArcUtils.java
+++ b/offsetanimator/src/main/java/com/russelarms/offsetanimator/util/ArcUtils.java
@@ -21,11 +21,11 @@ public class ArcUtils {
     }
 
     public static float centerX(View view) {
-        return view.getX() + view.getWidth() / 2;
+        return view.getX() + view.getWidth() / 2f;
     }
 
     public static float centerY(View view) {
-        return view.getY() + view.getHeight() / 2;
+        return view.getY() + view.getHeight() / 2f;
     }
 
 }


### PR DESCRIPTION
The result of the integer division is truncated to the integer value closest to zero. More on that [here](https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.17.2).